### PR TITLE
Fix example of creating retry with options

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,8 +142,8 @@ example, any function decorated with `retry` will be attempted for 10
 times with in 300ms intervals.
 
 ``` clojure
-(def retry (r/create {:max-attempts 10
-                    :wait-duration 300}))
+(def retry (r/create "name" {:max-attempts 10
+                             :wait-duration 300}))
 ```
 
 Resilience4clj provides a series of commonly-used interval


### PR DESCRIPTION
The indicated code doesn't work, as the function requires a string as the first argument