### PR TITLE
Update resilience4j version to 1.5.0

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -2,7 +2,8 @@
 
  :deps
  {org.clojure/clojure                       {:mvn/version "1.10.1"}
-  io.github.resilience4j/resilience4j-retry {:mvn/version "0.17.0"}}
+  io.github.resilience4j/resilience4j-core  {:mvn/version "1.5.0"}
+  io.github.resilience4j/resilience4j-retry {:mvn/version "1.5.0"}}
 
  :aliases
  {:dev

--- a/src/resilience4clj_retry/interval_functions.clj
+++ b/src/resilience4clj_retry/interval_functions.clj
@@ -1,6 +1,6 @@
 (ns resilience4clj-retry.interval-functions
   (:import
-   (io.github.resilience4j.retry IntervalFunction)))
+   (io.github.resilience4j.core IntervalFunction)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;Public functions

--- a/test/core_test.clj
+++ b/test/core_test.clj
@@ -24,7 +24,7 @@
     (is (= 3 max-attempts))
     (is (string/starts-with?
          (str (type interval-function))
-         "class io.github.resilience4j.retry.IntervalFunction$$Lambda"))))
+         "class io.github.resilience4j.core.IntervalFunction$$Lambda"))))
 
 (deftest create-custom-retry
   (let [{:keys [max-attempts
@@ -35,7 +35,7 @@
     (is (= 3 max-attempts))
     (is (string/starts-with?
          (str (type interval-function))
-         "class io.github.resilience4j.retry.IntervalFunction$$Lambda"))))
+         "class io.github.resilience4j.core.IntervalFunction$$Lambda"))))
 
 (deftest works-after-3-tries-2-failures
   (let [protected (retry/decorate (create-hello-works-after 2)


### PR DESCRIPTION
Update resilience4j version from 0.17.0 (the last one before the 1.0.0 release) to 1.5.0 (the most recent one at this time).

Since the interface `io.github.resilience4j.retry.IntervalFuction` was deprecated in favor of `io.github.resilience4j.core.IntervalFuction`, the core dependency was explicity added to the project (`io.github.resilience4j/resilience4j-core`) and the namespace `resilience4clj-retry.interval-functions` was changed to import `...core.IntervalFunction`. This change means that:

- 1.5.0 `RetryConfig`s are able to work properly when passed a 0.17.0 `...retry.IntervalFunction` or a `...core.IntervalFunction`
- 0.17.0 `RetryConfig`s are able to work properly when passed a 0.17.0 `...retry.IntervalFunction` but are not able to work properly with a 1.5.0 `...core.IntervalFunction`.

In this case, should this change be labeled as breaking change for the resilience4clj library?